### PR TITLE
Remove dead "User Documentation" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Elasticsearch support for [rom-rb](https://github.com/rom-rb/rom).
 
 Resources:
 
-- [User Documentation](http://rom-rb.org/learn/elasticsearch/)
 - [API Documentation](http://rubydoc.info/gems/rom-elasticsearch)
 
 ## Installation


### PR DESCRIPTION
This link results in a 404. I tried to find if the guide had moved but there doesn't appear to be any user documentation on [https://rom-rb.org/](https://rom-rb.org/).

If there's a better alternative than this this, let me know. I came to check out `rom-elasticsearch` and the first thing I did was click a dead link so it will probably drive other potential users away unless fixed or the documentation is added.