### PR TITLE
Fix keyword arguments usage

### DIFF
--- a/lib/rom/elasticsearch/dataset.rb
+++ b/lib/rom/elasticsearch/dataset.rb
@@ -65,7 +65,7 @@ module ROM
       TUPLE_PROC_WITH_METADATA = -> t { TUPLE_PROC[t].merge(_metadata: t) }
 
       # @api private
-      def initialize(*args)
+      def initialize(*args, **kwargs)
         super
         @tuple_proc = options[:include_metadata] ? TUPLE_PROC_WITH_METADATA : TUPLE_PROC
       end


### PR DESCRIPTION
It fixes keywords arguments usage according to the lates ruby specification: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

